### PR TITLE
Increase file descriptor limit to 2048

### DIFF
--- a/cores/Dockerfile
+++ b/cores/Dockerfile
@@ -162,6 +162,9 @@ WORKDIR /usr/web/store
 RUN /bin/bash -c "source /root/.bashrc; \
     npm install"
 
+# Increase file descriptor limit from default of 1024
+RUN ulimit -n 2048
+
 # Grab specifically the python server contents from the generic HMI repository
 RUN git clone https://github.com/smartdevicelink/generic_hmi.git /usr/web/python -b master --depth=1 --recurse-submodules
 


### PR DESCRIPTION
Fixes https://github.com/smartdevicelink/manticore/issues/130.

Increases the file descriptor limit for the docker process to avoid errors such as `error code 24 (Too many open files)`.