### PR TITLE
Add all apps to EMERGENCY priority which allows use of alerts as freely as possible

### DIFF
--- a/cores/policy/index.js
+++ b/cores/policy/index.js
@@ -162,7 +162,7 @@ function createAppPolicyObj (cloudPost, isSecure) {
     return {
         "keep_context": false,
         "steal_focus": false,
-        "priority": "NONE",
+        "priority": "EMERGENCY",
         "default_hmi": "NONE",
         "groups": ["Base-4", "Location-1", "Notifications", "Notifications-RC", "DrivingCharacteristics-3", "VehicleInfo-3", "PropriataryData-1", "PropriataryData-2", "ProprietaryData-3", "CloudAppStore", "CloudApp", "AppServiceProvider", "AppServiceConsumer", "RemoteControl", "Emergency-1", "Navigation-1", "Base-6", "OnKeyboardInputOnlyGroup", "OnTouchEventOnlyGroup", "DiagnosticMessageOnly", "DataConsent-2", "BaseBeforeDataConsent", "SendLocation", "WayPoints", "BackgroundAPT", "HapticGroup", "WidgetSupport"],
         "moduleType": ["CLIMATE", "RADIO", "SEAT", "AUDIO", "LIGHT", "HMI_SETTINGS"],

--- a/cores/sdl_preloaded_pt.json
+++ b/cores/sdl_preloaded_pt.json
@@ -2620,7 +2620,7 @@
             "default": {
                 "keep_context": false,
                 "steal_focus": false,
-                "priority": "NONE",
+                "priority": "EMERGENCY",
                 "default_hmi": "NONE",
                 "groups": ["Base-4", "Location-1", "Notifications", "Notifications-RC", "DrivingCharacteristics-3", "VehicleInfo-3", "PropriataryData-1", "PropriataryData-2", "ProprietaryData-3", "CloudAppStore", "CloudApp", "AppServiceProvider", "AppServiceConsumer", "RemoteControl", "Emergency-1", "Navigation-1", "Base-6", "OnKeyboardInputOnlyGroup", "OnTouchEventOnlyGroup", "DiagnosticMessageOnly", "DataConsent-2", "BaseBeforeDataConsent", "SendLocation", "WayPoints", "BackgroundAPT", "HapticGroup", "WidgetSupport"],
                 "moduleType": ["CLIMATE", "RADIO", "SEAT", "AUDIO", "LIGHT", "HMI_SETTINGS"],


### PR DESCRIPTION
Changing to EMERGENCY allows for 60 notifications per minute, which should be more than enough for any use case of Manticore