### PR TITLE
Include the empty app_bundles folders in the app store

### DIFF
--- a/cores/store/compressed_app_bundles/.gitignore
+++ b/cores/store/compressed_app_bundles/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/cores/store/decompressed_app_bundles/.gitignore
+++ b/cores/store/decompressed_app_bundles/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
This PR adds an empty folder to the app store server for it to save app bundles too. Any files in the folder will be ignored.