### PR TITLE
Import generic_hmi python file and remove logs and conditions that prevent functioning

### DIFF
--- a/cores/Dockerfile
+++ b/cores/Dockerfile
@@ -155,6 +155,10 @@ RUN bash -c "source $HOME/.nvm/nvm.sh   && \
 RUN git clone https://github.com/smartdevicelink/generic_hmi.git /usr/web/python -b master --depth=1 --recurse-submodules
 COPY start_server.py /usr/web/python/tools/start_server.py
 
+# Extra imports needed for the python server
+RUN apt-get install ffmpeg -y --no-install-recommends
+RUN pip3 install ffmpeg-python pexpect pyopenssl
+
 # Directory to run commands in
 WORKDIR /usr/build/bin
 

--- a/cores/supervisord.conf
+++ b/cores/supervisord.conf
@@ -29,6 +29,6 @@ command=/bin/bash -c "/root/.nvm/versions/node/v8.11.1/bin/node /usr/web/store/i
 
 [program:python]
 priority=80
-command=/bin/bash -c "python3 /usr/web/python/python_websocket/src/start_server.py --host=${DOCKER_IP} --port=8081"
+command=/bin/bash -c "python3 /usr/web/python/python_websocket/src/start_server.py --host=${DOCKER_IP} --ws-port=8081"
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
The generic_hmi has an updated start_server.py file that should get used for Manticore's core image: https://github.com/smartdevicelink/generic_hmi/blob/master/tools/start_server.py

New libraries for the OS and for python needed to be added to support the new program.

The problem with it is that certain message logs crash the program when running inside the image. These logs are removed.

The other issue is the validate file path method: https://github.com/smartdevicelink/generic_hmi/blob/master/tools/start_server.py#L262

This checks if any file attempted to be saved is saving in a directory outside the program. Manticore necessitates saving the policy file elsewhere which is why policy table updates will fail. A change has been made to remove that restriction.