### PR TITLE
Fix cloud apps being given default permissions on future PTUs

### DIFF
--- a/cores/policy/index.js
+++ b/cores/policy/index.js
@@ -82,7 +82,7 @@ router.post('/api/v1/production/policy', async (ctx, next) => {
             if (appId !== "default" && appId !== "device" && appId !== "pre_DataConsent") {
                 if (appsRequestingWebView.includes(appId)) {
                     table.policy_table.app_policies[appId] = webViewPolicyObj;
-                } else {
+                } else if (table.policy_table.app_policies[appId] === undefined) {
                     table.policy_table.app_policies[appId] = "default";
                 }
             }


### PR DESCRIPTION
Fixes [issue](https://github.com/smartdevicelink/manticore/issues/161)
As is, manticore's policy server will force default permissions to anything connecting that isn't a webview app. This means any cloud apps will disconnect because core no longer has their connection info. This PR updates the internal policy server to only give default permissions if the app did not already have an entry in the policy table.