### PR TITLE
Add route to get list of cloud apps from policy server

### DIFF
--- a/cores/policy/index.js
+++ b/cores/policy/index.js
@@ -102,6 +102,33 @@ const cloudPostSchema = Joi.object().keys({
     nicknames: Joi.array().items(Joi.string()).required()
 })
 
+router.get('/api/v1/cloud', async (ctx, next) => {
+
+    let table = JSON.parse(await readFile(ptPath))
+    let results = []
+
+    for (let appId in table.policy_table.app_policies) {
+        if (appId !== "default" && appId !== "device" && appId !== "pre_DataConsent") {
+
+            let request = {
+                app_id: appId,
+                endpoint: table.policy_table.app_policies[appId].endpoint,
+                auth_token: table.policy_table.app_policies[appId].auth_token,
+                nicknames: table.policy_table.app_policies[appId].nicknames
+            }
+
+            results.push(request);
+        }
+    }
+    await writeFile(ptOutPath, JSON.stringify(table, null, 4))
+
+    ctx.response.status = 200
+    return ctx.body = {
+        app_policies: results,
+        ptLocation: ptOutPath
+    }
+})
+
 //the Manticore UI hits this endpoint
 router.post('/api/v1/cloud', async (ctx, next) => {
     const { body } = ctx.request

--- a/cores/policy/index.js
+++ b/cores/policy/index.js
@@ -103,29 +103,22 @@ const cloudPostSchema = Joi.object().keys({
 })
 
 router.get('/api/v1/cloud', async (ctx, next) => {
-
     let table = JSON.parse(await readFile(ptPath))
     let results = []
-
     for (let appId in table.policy_table.app_policies) {
         if (appId !== "default" && appId !== "device" && appId !== "pre_DataConsent") {
-
             let request = {
                 app_id: appId,
                 endpoint: table.policy_table.app_policies[appId].endpoint,
                 auth_token: table.policy_table.app_policies[appId].auth_token,
                 nicknames: table.policy_table.app_policies[appId].nicknames
             }
-
             results.push(request);
         }
     }
-    await writeFile(ptOutPath, JSON.stringify(table, null, 4))
-
     ctx.response.status = 200
     return ctx.body = {
-        app_policies: results,
-        ptLocation: ptOutPath
+        app_policies: results
     }
 })
 


### PR DESCRIPTION
Manticore cloud apps do not appear in sidebar if the page refreshes. Add rout to get list of cloud apps from policy server. Issue: https://github.com/smartdevicelink/manticore/issues/170